### PR TITLE
Features/upsert operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,7 @@ This is the structure for each sObject
 	"fieldsToExport": "FirstName,LastName,Email,Id",
 	"matchBy": "Email",
 	"orderBy": "LastName",
-	"twoPassReferenceFields": "Foo__c,Bar__c",
-	"where": null,
-	"externalIdField": null
+	"where": null
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ You must provide the name of the sObject
 	"ignoreFields": "OwnerId, IgnoreField__c",
 	"maxRecords": 50,
 	"orderBy": "City__c",
-	"where": "State__c = 'Texas'"
+	"where": "State__c = 'Texas'",
+	"externalIdField": "External_Id_Field__c"
 }
 ```
 
@@ -121,6 +122,7 @@ This is the structure for each sObject
 | orderBy                | null    | String    | For exports, determines the order for the records that are exported.                                                       |
 | twoPassReferenceFields | null    | String[]  | For imports, lists the fields that need to be set using a separate update as they refer an SObject that is not loaded yet. |
 | where                  | null    | String    | Restrict which records are be exported.                                                                                    |
+| externalIdField        | null    | String    | API name of external ID field to be used for an upsert operation.                                                                                    |
 
 ## sObjectsMetadata
 
@@ -143,7 +145,8 @@ This is the structure for each sObject
 	"matchBy": "Email",
 	"orderBy": "LastName",
 	"twoPassReferenceFields": "Foo__c,Bar__c",
-	"where": null
+	"where": null,
+	"externalIdField": null
 }
 ```
 

--- a/src/@ELTOROIT/Settings.ts
+++ b/src/@ELTOROIT/Settings.ts
@@ -24,6 +24,7 @@ export interface ISettingsSObjectData extends ISettingsSObjectBase {
 	ignoreFields: string | string[];
 	twoPassReferenceFields: string | string[];
 	maxRecords: number;
+	externalIdField: string;
 }
 
 // NOTE: Metadata in the configuration file
@@ -497,7 +498,8 @@ export class Settings implements ISettingsValues {
 			maxRecords: -1,
 			name: sObjName,
 			orderBy: null,
-			where: null
+			where: null,
+			externalIdField: null
 		};
 		// LEARNING: [OBJECT]: How to loop through the values of an JSON object, which is not a Typescript Map.
 		Object.keys(sObject).forEach((key) => {
@@ -645,7 +647,8 @@ export class Settings implements ISettingsValues {
 				maxRecords: this.maxRecordsEachRaw,
 				name: null,
 				orderBy: null,
-				where: null
+				where: null,
+				externalIdField: null
 			};
 			this.blankSObjectData = output;
 		}


### PR DESCRIPTION
Adding new configuration attribute to provide an `externalIdField` per object that will trigger an upsert operation instead of an insert. This way, if the source data is already in the target, you don't need to delete all records to avoid duplicates. 