### PR TITLE
Features/two pass update fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,13 @@ You must provide the name of the sObject
 ```
 {
 	"name": "Location__c",
+	"externalIdField": "External_Id_Field__c",
 	"ignoreFields": "OwnerId, IgnoreField__c",
 	"maxRecords": 50,
 	"orderBy": "City__c",
-	"where": "State__c = 'Texas'",
-	"externalIdField": "External_Id_Field__c"
+    "twoPassReferenceFields": "Foo__c,Bar__c",
+	"twoPassUpdateFields": "Not_a_Lookup_Field__c,A_Text_Field__c",
+	"where": "State__c = 'Texas'"
 }
 ```
 
@@ -121,6 +123,7 @@ This is the structure for each sObject
 | maxRecords             | -1      | Integer   | Overrides the global **maxRecordsEach** field.                                                                             |
 | orderBy                | null    | String    | For exports, determines the order for the records that are exported.                                                       |
 | twoPassReferenceFields | null    | String[]  | For imports, lists the fields that need to be set using a separate update as they refer an SObject that is not loaded yet. |
+| twoPassUpdateFields    | null    | String[]  | For imports, lists the fields that need to be set using a separate update request along with the **twoPassreferenceFields**.|
 | where                  | null    | String    | Restrict which records are be exported.                                                                                    |
 | externalIdField        | null    | String    | API name of external ID field to be used for an upsert operation.                                                                                    |
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ You must provide the name of the sObject
 	"ignoreFields": "OwnerId, IgnoreField__c",
 	"maxRecords": 50,
 	"orderBy": "City__c",
-	"where": "State__c = 'Texas'"
+	"where": "State__c = 'Texas'",
+	"externalIdField": "External_Id_Field__c"
 }
 ```
 
@@ -121,6 +122,7 @@ This is the structure for each sObject
 | orderBy                | null    | String    | For exports, determines the order for the records that are exported.                                                       |
 | twoPassReferenceFields | null    | String[]  | For imports, lists the fields that need to be set using a separate update as they refer an SObject that is not loaded yet. |
 | where                  | null    | String    | Restrict which records are be exported.                                                                                    |
+| externalIdField        | null    | String    | API name of external ID field to be used for an upsert operation.                                                                                    |
 
 ## sObjectsMetadata
 
@@ -143,7 +145,8 @@ This is the structure for each sObject
 	"matchBy": "Email",
 	"orderBy": "LastName",
 	"twoPassReferenceFields": "Foo__c,Bar__c",
-	"where": null
+	"where": null,
+	"externalIdField": null
 }
 ```
 

--- a/src/@ELTOROIT/Settings.ts
+++ b/src/@ELTOROIT/Settings.ts
@@ -24,6 +24,7 @@ export interface ISettingsSObjectData extends ISettingsSObjectBase {
 	ignoreFields: string | string[];
 	twoPassReferenceFields: string | string[];
 	maxRecords: number;
+	externalIdField: string;
 }
 
 // NOTE: Metadata in the configuration file
@@ -497,7 +498,8 @@ export class Settings implements ISettingsValues {
 			maxRecords: -1,
 			name: sObjName,
 			orderBy: null,
-			where: null
+			where: null,
+			externalIdField: null
 		};
 		// LEARNING: [OBJECT]: How to loop through the values of an JSON object, which is not a Typescript Map.
 		Object.keys(sObject).forEach((key) => {
@@ -645,7 +647,8 @@ export class Settings implements ISettingsValues {
 				maxRecords: this.maxRecordsEachRaw,
 				name: null,
 				orderBy: null,
-				where: null
+				where: null,
+				externalIdField: null
 			};
 			this.blankSObjectData = output;
 		}

--- a/src/@ELTOROIT/Settings.ts
+++ b/src/@ELTOROIT/Settings.ts
@@ -23,6 +23,7 @@ interface ISettingsSObjectBase {
 export interface ISettingsSObjectData extends ISettingsSObjectBase {
 	ignoreFields: string | string[];
 	twoPassReferenceFields: string | string[];
+	twoPassUpdateFields: string | string[];
 	maxRecords: number;
 	externalIdField: string;
 }
@@ -44,6 +45,7 @@ export interface ISettingsValues {
 	copyToProduction: boolean;
 	ignoreFieldsRaw: string;
 	twoPassReferenceFieldsRaw: string;
+	twoPassUpdateFieldsRaw: string;
 	maxRecordsEachRaw: number;
 	deleteDestination: boolean;
 	// LEARNING: Salesforce default is 10,000
@@ -78,6 +80,7 @@ export class Settings implements ISettingsValues {
 	public sObjectsMetadataRaw: Map<string, ISettingsSObjectMetatada>;
 	public ignoreFieldsRaw: string;
 	public twoPassReferenceFieldsRaw: string;
+	public twoPassUpdateFieldsRaw: string;
 	public includeAllCustom: boolean;
 	public stopOnErrors: boolean;
 	public copyToProduction: boolean;
@@ -140,6 +143,7 @@ export class Settings implements ISettingsValues {
 			// Fix fields
 			output.ignoreFields = Util.mergeAndCleanArrays(output.ignoreFields as string, this.ignoreFieldsRaw);
 			output.twoPassReferenceFields = Util.mergeAndCleanArrays(output.twoPassReferenceFields as string, this.twoPassReferenceFieldsRaw);
+			output.twoPassUpdateFields = Util.mergeAndCleanArrays(output.twoPassUpdateFields as string, this.twoPassUpdateFieldsRaw);
 			if (this.maxRecordsEachRaw > 0 && output.maxRecords === -1) {
 				output.maxRecords = this.maxRecordsEachRaw;
 			}
@@ -391,6 +395,13 @@ export class Settings implements ISettingsValues {
 						})
 					);
 
+					// twoPassUpdateFieldsRaw
+					promises.push(
+						this.processStringValues(resValues, "twoPassUpdateFields", false).then((value: string) => {
+							this.twoPassUpdateFieldsRaw = value;
+						})
+					);
+
 					// maxRecordsEach
 					promises.push(
 						this.processStringValues(resValues, "maxRecordsEach", false)
@@ -495,6 +506,7 @@ export class Settings implements ISettingsValues {
 		const newValue: ISettingsSObjectData = {
 			ignoreFields: null,
 			twoPassReferenceFields: null,
+			twoPassUpdateFields: null,
 			maxRecords: -1,
 			name: sObjName,
 			orderBy: null,
@@ -559,6 +571,7 @@ export class Settings implements ISettingsValues {
 		output.ignoreFields = this.ignoreFieldsRaw;
 		output.copyToProduction = this.copyToProduction;
 		output.twoPassReferenceFields = this.twoPassReferenceFieldsRaw;
+		output.twoPassUpdateFields = this.twoPassUpdateFieldsRaw;
 		output.maxRecordsEach = this.maxRecordsEachRaw;
 		output.deleteDestination = this.deleteDestination;
 		output.pollingTimeout = this.pollingTimeout;
@@ -597,7 +610,7 @@ export class Settings implements ISettingsValues {
 					let value = sObj[fieldName];
 
 					if (isVerbose) {
-						if (["ignoreFields", "twoPassReferenceFields", "fieldsToExport"].includes(fieldName)) {
+						if (["ignoreFields", "twoPassReferenceFields", "twoPassUpdateFields", "fieldsToExport"].includes(fieldName)) {
 							value = value.toString();
 						}
 					} else {
@@ -632,6 +645,7 @@ export class Settings implements ISettingsValues {
 		this.copyToProduction = false;
 		this.ignoreFieldsRaw = null;
 		this.twoPassReferenceFieldsRaw = null;
+		this.twoPassUpdateFieldsRaw = null;
 		this.maxRecordsEachRaw = -1;
 		this.deleteDestination = false;
 		this.pollingTimeout = 100000;
@@ -640,10 +654,12 @@ export class Settings implements ISettingsValues {
 	private getBlankSObjectData(sObjName: string): ISettingsSObjectData {
 		let output: ISettingsSObjectData = this.blankSObjectData;
 
+		Util.writeLog(`Creating blank outout object: ${output}`, LogLevel.TRACE);
 		if (output === null) {
 			output = {
 				ignoreFields: Util.mergeAndCleanArrays(this.ignoreFieldsRaw, ""),
 				twoPassReferenceFields: Util.mergeAndCleanArrays(this.twoPassReferenceFieldsRaw, ""),
+				twoPassUpdateFields: Util.mergeAndCleanArrays(this.twoPassUpdateFieldsRaw, ""),
 				maxRecords: this.maxRecordsEachRaw,
 				name: null,
 				orderBy: null,


### PR DESCRIPTION
There might be a situation where a `twoPassReferenceFields` requires a non-reference field to be included in the `update` request to avoid validation failures of the operation. For this case, a new configuration attribute called `twoPassUpdateFields` has been created. It follows the same syntax as the reference setting, and will add all of the fields listed in the same update request. 
This configuration value can also be used standalone without an entry in `twoPassReferenceFields`.