### PR TITLE
Features/ci enablement

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,13 @@ You must provide the name of the sObject
 ```
 {
 	"name": "Location__c",
+	"externalIdField": "External_Id_Field__c",
 	"ignoreFields": "OwnerId, IgnoreField__c",
 	"maxRecords": 50,
 	"orderBy": "City__c",
-	"where": "State__c = 'Texas'",
-	"externalIdField": "External_Id_Field__c"
+    "twoPassReferenceFields": "Foo__c,Bar__c",
+	"twoPassUpdateFields": "Not_a_Lookup_Field__c,A_Text_Field__c",
+	"where": "State__c = 'Texas'"
 }
 ```
 
@@ -121,6 +123,7 @@ This is the structure for each sObject
 | maxRecords             | -1      | Integer   | Overrides the global **maxRecordsEach** field.                                                                             |
 | orderBy                | null    | String    | For exports, determines the order for the records that are exported.                                                       |
 | twoPassReferenceFields | null    | String[]  | For imports, lists the fields that need to be set using a separate update as they refer an SObject that is not loaded yet. |
+| twoPassUpdateFields    | null    | String[]  | For imports, lists the fields that need to be set using a separate update request along with the **twoPassreferenceFields**.|
 | where                  | null    | String    | Restrict which records are be exported.                                                                                    |
 | externalIdField        | null    | String    | API name of external ID field to be used for an upsert operation.                                                                                    |
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ You must provide the name of the sObject
 	"ignoreFields": "OwnerId, IgnoreField__c",
 	"maxRecords": 50,
 	"orderBy": "City__c",
-	"where": "State__c = 'Texas'"
+	"where": "State__c = 'Texas'",
+	"externalIdField": "External_Id_Field__c"
 }
 ```
 
@@ -121,6 +122,7 @@ This is the structure for each sObject
 | orderBy                | null    | String    | For exports, determines the order for the records that are exported.                                                       |
 | twoPassReferenceFields | null    | String[]  | For imports, lists the fields that need to be set using a separate update as they refer an SObject that is not loaded yet. |
 | where                  | null    | String    | Restrict which records are be exported.                                                                                    |
+| externalIdField        | null    | String    | API name of external ID field to be used for an upsert operation.                                                                                    |
 
 ## sObjectsMetadata
 
@@ -143,7 +145,8 @@ This is the structure for each sObject
 	"matchBy": "Email",
 	"orderBy": "LastName",
 	"twoPassReferenceFields": "Foo__c,Bar__c",
-	"where": null
+	"where": null,
+	"externalIdField": null
 }
 ```
 

--- a/src/@ELTOROIT/ETCopyData.ts
+++ b/src/@ELTOROIT/ETCopyData.ts
@@ -31,6 +31,10 @@ export class ETCopyData {
 			description: "SFDX alias or username for the SOURCE org",
 			helpValue: "(alias|username)"
 		}),
+		deletedestination: flags.boolean({
+			char: "r",
+			description: "Delete records in destination org prior to data loads"
+		}),
 		forceprodcopy: flags.boolean({
 			description: 'Force the copy to production'
 		}),
@@ -68,6 +72,10 @@ export class ETCopyData {
 		if (params.orgdestination) {
 			Util.writeLog(`Parameter: destination [${params.orgdestination}]`, LogLevel.TRACE);
 			s.orgAliases.set(WhichOrg.DESTINATION, params.orgdestination);
+		}
+		if (params.deletedestination) {
+			Util.writeLog(`Parameter: deletedestination [${params.deletedestination}]`, LogLevel.TRACE);
+			s.deleteDestination = true;
 		}
 		if (params.forceprodcopy) {
 			Util.writeLog(`Parameter: forceprodcopy [${params.forceprodcopy}]`, LogLevel.TRACE);

--- a/src/@ELTOROIT/Importer.ts
+++ b/src/@ELTOROIT/Importer.ts
@@ -467,7 +467,7 @@ export class Importer {
 							});
 						}
 
-						const recordsToUpdate = [...records.values()];
+						const recordsToUpdate: Array<any> = [...records.values()];
 
 						Util.writeLog(`[${orgDestination.alias}] [${sObjectName}] recordsToUpdate: ${JSON.stringify(recordsToUpdate)}`, LogLevel.TRACE);
 						

--- a/src/@ELTOROIT/Settings.ts
+++ b/src/@ELTOROIT/Settings.ts
@@ -414,11 +414,17 @@ export class Settings implements ISettingsValues {
 					);
 
 					// deleteDestination
-					promises.push(
-						this.processStringValues(resValues, "deleteDestination", false).then((value: string) => {
-							this.deleteDestination = value === "true";
-						})
-					);
+					if (overrideSettings.deleteDestination) {
+						msg = `Configuration value for [deleteDestination] read from command line: ${overrideSettings.deleteDestination}`;
+						this.deleteDestination = overrideSettings.deleteDestination;
+						Util.writeLog(msg, LogLevel.INFO);
+					} else {
+						promises.push(
+							this.processStringValues(resValues, "deleteDestination", false).then((value: string) => {
+								this.deleteDestination = value === "true";
+							})
+						);
+					}
 
 					// pollingTimeout
 					promises.push(

--- a/src/@ELTOROIT/Settings.ts
+++ b/src/@ELTOROIT/Settings.ts
@@ -24,6 +24,7 @@ export interface ISettingsSObjectData extends ISettingsSObjectBase {
 	ignoreFields: string | string[];
 	twoPassReferenceFields: string | string[];
 	maxRecords: number;
+	externalIdField: string;
 }
 
 // NOTE: Metadata in the configuration file
@@ -497,7 +498,8 @@ export class Settings implements ISettingsValues {
 			maxRecords: -1,
 			name: sObjName,
 			orderBy: null,
-			where: null
+			where: null,
+			externalIdField: null
 		};
 		// LEARNING: [OBJECT]: How to loop through the values of an JSON object, which is not a Typescript Map.
 		Object.keys(sObject).forEach((key) => {
@@ -645,7 +647,8 @@ export class Settings implements ISettingsValues {
 				maxRecords: this.maxRecordsEachRaw,
 				name: null,
 				orderBy: null,
-				where: null
+				where: null,
+				externalIdField: null
 			};
 			this.blankSObjectData = output;
 		}

--- a/src/@ELTOROIT/Settings.ts
+++ b/src/@ELTOROIT/Settings.ts
@@ -23,6 +23,7 @@ interface ISettingsSObjectBase {
 export interface ISettingsSObjectData extends ISettingsSObjectBase {
 	ignoreFields: string | string[];
 	twoPassReferenceFields: string | string[];
+	twoPassUpdateFields: string | string[];
 	maxRecords: number;
 	externalIdField: string;
 }
@@ -44,6 +45,7 @@ export interface ISettingsValues {
 	copyToProduction: boolean;
 	ignoreFieldsRaw: string;
 	twoPassReferenceFieldsRaw: string;
+	twoPassUpdateFieldsRaw: string;
 	maxRecordsEachRaw: number;
 	deleteDestination: boolean;
 	// LEARNING: Salesforce default is 10,000
@@ -78,6 +80,7 @@ export class Settings implements ISettingsValues {
 	public sObjectsMetadataRaw: Map<string, ISettingsSObjectMetatada>;
 	public ignoreFieldsRaw: string;
 	public twoPassReferenceFieldsRaw: string;
+	public twoPassUpdateFieldsRaw: string;
 	public includeAllCustom: boolean;
 	public stopOnErrors: boolean;
 	public copyToProduction: boolean;
@@ -140,6 +143,7 @@ export class Settings implements ISettingsValues {
 			// Fix fields
 			output.ignoreFields = Util.mergeAndCleanArrays(output.ignoreFields as string, this.ignoreFieldsRaw);
 			output.twoPassReferenceFields = Util.mergeAndCleanArrays(output.twoPassReferenceFields as string, this.twoPassReferenceFieldsRaw);
+			output.twoPassUpdateFields = Util.mergeAndCleanArrays(output.twoPassUpdateFields as string, this.twoPassUpdateFieldsRaw);
 			if (this.maxRecordsEachRaw > 0 && output.maxRecords === -1) {
 				output.maxRecords = this.maxRecordsEachRaw;
 			}
@@ -391,6 +395,13 @@ export class Settings implements ISettingsValues {
 						})
 					);
 
+					// twoPassUpdateFieldsRaw
+					promises.push(
+						this.processStringValues(resValues, "twoPassUpdateFields", false).then((value: string) => {
+							this.twoPassUpdateFieldsRaw = value;
+						})
+					);
+
 					// maxRecordsEach
 					promises.push(
 						this.processStringValues(resValues, "maxRecordsEach", false)
@@ -495,6 +506,7 @@ export class Settings implements ISettingsValues {
 		const newValue: ISettingsSObjectData = {
 			ignoreFields: null,
 			twoPassReferenceFields: null,
+			twoPassUpdateFields: null,
 			maxRecords: -1,
 			name: sObjName,
 			orderBy: null,
@@ -559,6 +571,7 @@ export class Settings implements ISettingsValues {
 		output.ignoreFields = this.ignoreFieldsRaw;
 		output.copyToProduction = this.copyToProduction;
 		output.twoPassReferenceFields = this.twoPassReferenceFieldsRaw;
+		output.twoPassUpdateFields = this.twoPassUpdateFieldsRaw;
 		output.maxRecordsEach = this.maxRecordsEachRaw;
 		output.deleteDestination = this.deleteDestination;
 		output.pollingTimeout = this.pollingTimeout;
@@ -597,7 +610,7 @@ export class Settings implements ISettingsValues {
 					let value = sObj[fieldName];
 
 					if (isVerbose) {
-						if (["ignoreFields", "twoPassReferenceFields", "fieldsToExport"].includes(fieldName)) {
+						if (["ignoreFields", "twoPassReferenceFields", "twoPassUpdateFields", "fieldsToExport"].includes(fieldName)) {
 							value = value.toString();
 						}
 					} else {
@@ -632,6 +645,7 @@ export class Settings implements ISettingsValues {
 		this.copyToProduction = false;
 		this.ignoreFieldsRaw = null;
 		this.twoPassReferenceFieldsRaw = null;
+		this.twoPassUpdateFieldsRaw = null;
 		this.maxRecordsEachRaw = -1;
 		this.deleteDestination = false;
 		this.pollingTimeout = 100000;
@@ -640,10 +654,12 @@ export class Settings implements ISettingsValues {
 	private getBlankSObjectData(sObjName: string): ISettingsSObjectData {
 		let output: ISettingsSObjectData = this.blankSObjectData;
 
+		Util.writeLog(`Creating blank outout object: ${output}`, LogLevel.TRACE);
 		if (output === null) {
 			output = {
 				ignoreFields: Util.mergeAndCleanArrays(this.ignoreFieldsRaw, ""),
 				twoPassReferenceFields: Util.mergeAndCleanArrays(this.twoPassReferenceFieldsRaw, ""),
+				twoPassUpdateFields: Util.mergeAndCleanArrays(this.twoPassUpdateFieldsRaw, ""),
 				maxRecords: this.maxRecordsEachRaw,
 				name: null,
 				orderBy: null,

--- a/src/@ELTOROIT/Settings.ts
+++ b/src/@ELTOROIT/Settings.ts
@@ -90,6 +90,8 @@ export class Settings implements ISettingsValues {
 	public rootFolderRaw: string;
 	public rootFolderFull: string;
 	public configfolder: string;
+	public forceProductionCopy: boolean;
+	public forceProductionDeletion: boolean;
 
 	// Local private variables
 	private configFile: ConfigFile<ConfigFile.Options> = null;
@@ -424,6 +426,9 @@ export class Settings implements ISettingsValues {
 							this.pollingTimeout = parseInt(value, 10);
 						})
 					);
+
+					this.forceProductionCopy = overrideSettings.forceProductionCopy;
+					this.forceProductionDeletion = overrideSettings.forceProductionDeletion;
 
 					Promise.all(promises)
 						.then(() => {


### PR DESCRIPTION
Currently, `ETCopyData` prevents users from deleting records in production as well as it creates console prompts to validate any deployment to a production org. While those gates are good, they can be limiting when using `ETCopyData` in a CI/CD environment as part of the deployment. The deployment should succeed for all environments, not just sandboxes. 

New command line flags `--deletedestination (-r)`, `--forceprodcopy`, and `--forceproddeletion` were created to set the `deleteDestination` value to true, disable the check that would prevent the execution of the load into a production org, and avoid the prompts in the command line. 